### PR TITLE
Add instruction to install tailspin on Archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ apt install tailspin
 tailspin [file]
 ```
 
+### Archlinux
+
+```console
+# Install
+paru -S tailspin
+
+# View log file
+spin [file]
+```
+
 > **Note**
 > Because of a name collision with another `apt` package, the binary name on Debian is `tailspin`
 


### PR DESCRIPTION
I just created a tailspin package in the Archlinux user repository, so people can install it using their favourite AUR helper.