### PR TITLE
Allow `Date` styles to be hidden in log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +903,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "ctrlc",
+ "indoc",
  "lazy_static",
  "linemux",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ tempfile = "3.8.0"
 terminal_size = "0.3.0"
 tokio = { version = "1.32.0", features = ["full"] }
 toml = "0.8.1"
+
+[dev-dependencies]
+indoc = "2"
+

--- a/src/highlighters/date.rs
+++ b/src/highlighters/date.rs
@@ -78,7 +78,6 @@ impl Highlight for DateHighlighter {
                             result.push(format!("{}{}{}", zone, reg_match.as_str(), color::RESET))
                         }
                     }
-                    // TODO: not sure how to handle the `same` case
                     Part::Equals => result.push(format!("{}", reg_match.as_str())),
                 }
             }
@@ -157,7 +156,6 @@ mod tests {
         let hltr = DateHighlighter::new(&date_style, &time_style, &zone_style);
         let input = "2022-09-09 11:44:54,508 INFO test";
 
-        // Separated by section for easier reading
         let expected: String = formatdoc!(
             "
             {date_ansi}2022-09-09{RESET_ANSI}
@@ -186,7 +184,7 @@ mod tests {
             {zone_ansi} {RESET_ANSI}
             {time_ansi}11:44:54{RESET_ANSI}
             {zone_ansi},508{RESET_ANSI}
-             INFO test",
+             INFO test", // note space
         )
         .replace("\n", "");
 
@@ -229,7 +227,7 @@ mod tests {
             {date_ansi}2022-09-09{RESET_ANSI}
             {time_ansi}11:44:54{RESET_ANSI}
             {time_ansi},508{RESET_ANSI}
-             INFO test",
+             INFO test", // note space
         )
         .replace("\n", "");
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -5,6 +5,8 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize, Default, Clone)]
 pub struct Style {
     #[serde(default)]
+    pub hidden: bool,
+    #[serde(default)]
     pub fg: Fg,
     #[serde(default)]
     pub bg: Bg,


### PR DESCRIPTION
## Description

This PR allows for a Date style to be hidden in log output. Fixes #44!

```toml
# config.toml
[groups.date]
date = { hidden = true}
time = { hidden = true}
zone = { hidden = true}
```

Example:
```log
# Before
2022-09-09 11:44:54,508 [Worker-2: Loading available Gradle versions] INFO  # other stuff
2022-09-09 11:47:47,193 [Worker-3: Importing Maven projects] INFO           # other stuff
2022-09-09 11:47:47,783 [Worker-3: Importing Maven projects] INFO           # other stuff

# After
[Worker-2: Loading available Gradle versions] INFO  # other stuff
[Worker-3: Importing Maven projects] INFO           # other stuff
[Worker-3: Importing Maven projects] INFO           # other stuff
```

## Contents

- `Style` now has a `hidden: Bool` flag
- Refactored `DateHighlighter.apply(_:)` logic
- Added tests
- Added [indoc](https://lib.rs/crates/indoc) crate for nice test macro formatting