### PR TITLE
Publish pre-built binaries to GitHub releases

### DIFF
--- a/.github/workflows/ReleaseStaticBinaries.yml
+++ b/.github/workflows/ReleaseStaticBinaries.yml
@@ -42,6 +42,6 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/tailspin
-        asset_name: tailspin-${{ matrix.target}}
+        file: target/${{ matrix.target }}/release/tspin
+        asset_name: tspin-${{ matrix.target}}
         tag: ${{ github.ref }}

--- a/.github/workflows/ReleaseStaticBinaries.yml
+++ b/.github/workflows/ReleaseStaticBinaries.yml
@@ -1,0 +1,47 @@
+name: Release static binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release-binaries:
+    name: Release ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+
+    - name: Install cargo-rs
+      shell: bash
+      run: |
+        cargo install cross
+
+    - name: Build
+      run: cross build --target ${{ matrix.target }} --release
+
+    - name: Upload binaries to GitHub Release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/${{ matrix.target }}/release/tailspin
+        asset_name: tailspin-${{ matrix.target}}
+        tag: ${{ github.ref }}


### PR DESCRIPTION
This PR adds a workflow to publish pre-build static binaries to GitHub releases.

Example:
  * Release Page - https://github.com/ecarrara/tailspin/releases/tag/v0
  * Workflow Run - https://github.com/ecarrara/tailspin/actions/runs/6866488646

Closes #74 

