### PR TITLE
Add windows to static binary GitHub Release Action

### DIFF
--- a/.github/workflows/ReleaseStaticBinaries.yml
+++ b/.github/workflows/ReleaseStaticBinaries.yml
@@ -16,32 +16,19 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
-        target: ${{ matrix.target }}
-
-    - name: Install cargo-rs
-      shell: bash
-      run: |
-        cargo install cross
-
-    - name: Build
-      run: cross build --target ${{ matrix.target }} --release
-
-    - name: Upload binaries to GitHub Release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/tspin
-        asset_name: tspin-${{ matrix.target}}
-        tag: ${{ github.ref }}
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tspin
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Builds on #87 

I wanted Windows binaries too, and mainly support for `cargo binstall` as previously mentioned.

From the documentation, it seems it requires archives with the binary contained rather than raw binaries in the release assets, so I swapped to using a well-known action for creating release assets in the expected format. If this isn't desired, I think it might be doable building on the previous steps.

This action also uses `cross` internally for cross compilation.

A test release: https://github.com/supleed2/tailspin/releases/tag/test
The corresponding runs: https://github.com/supleed2/tailspin/actions/runs/6881463683