### PR TITLE
Fix binary release assets archive names

### DIFF
--- a/.github/workflows/ReleaseStaticBinaries.yml
+++ b/.github/workflows/ReleaseStaticBinaries.yml
@@ -31,4 +31,5 @@ jobs:
         with:
           bin: tspin
           target: ${{ matrix.target }}
+          archive: tailspin-$target
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sorry about this! 😅

I saw the v2.2.0 release and tried installing via `cargo binstall` but it seems I missed that the archive name should match the crate name not the binary name when I made #88

This PR just adds the missing option to set the archive name correctly.

Test release with the correct archive names: https://github.com/supleed2/tailspin/releases/tag/v2.2.0