### PR TITLE
Update README since tailspin is now an official arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ brew install tailspin
 # Cargo
 cargo install tailspin
 
-# AUR
-paru -S tailspin
+# Archlinux
+pacman -S tailspin
 
 # Nix
 nix-shell -p tailspin


### PR DESCRIPTION
Since tailspin is now an official archlinux package, you can simply use pacman to install it.