### PR TITLE
More strict compiler diagniostics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,22 @@ rust-version = "1.70"
 path = "src/main.rs"
 name = "tspin"
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [lints.clippy]
-missing-const-for-fn = "warn"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_sign_loss = "deny"
+enum_glob_use = "deny"
+if_not_else = "deny"
+items_after_statements = "deny"
+missing-const-for-fn = "deny"
+mut_mut = "deny"
+panic = "deny"
+similar_names = "deny"
+unicode_not_nfc = "deny"
+used_underscore_binding = "deny"
 
 [dependencies]
 async-trait = "0.1.83"

--- a/src/highlighter/groups.rs
+++ b/src/highlighter/groups.rs
@@ -1,7 +1,7 @@
 use crate::cli::HighlighterGroup;
 use std::fmt::Debug;
 use thiserror::Error;
-use HighlighterConfigNew::*;
+use HighlighterConfigNew::{AllHighlightersEnabled, Mismatch, SomeHighlightersDisabled, SomeHighlightersEnabled};
 
 pub enum HighlighterConfigNew {
     AllHighlightersEnabled,


### PR DESCRIPTION
Prevent the usage of unsafe code and misc possible dangerous patterns, e.g. truncations.