### PR TITLE
chore(ci): upgrade actions/checkout to v7 in workflow files

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           token: ${{secrets.GH_PAT}}
           fetch-depth: 0

--- a/.github/workflows/ReleaseStaticBinaries.yml
+++ b/.github/workflows/ReleaseStaticBinaries.yml
@@ -26,7 +26,7 @@ jobs:
             target: x86_64-pc-windows-msvc
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: tspin


### PR DESCRIPTION
Upgrade actions/checkout v3 → v7 in all three GitHub Actions workflows; existing options unchanged.